### PR TITLE
Build from sources

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -14,8 +14,7 @@ class DoxygenInstallerConan(ConanFile):
     homepage = "https://github.com/doxygen/doxygen"
     author = "Inexor <info@inexor.org>"
     license = "GPL-2.0-only"
-    exports = ["LICENSE", "FindDoxygen.cmake"]
-    exports_sources = ["FindDoxygen.cmake"]
+    exports = ["LICENSE"]
 
     settings = "os_build", "arch_build", "compiler", "arch"
     options = {"build_from_source": [False, True]}
@@ -48,14 +47,10 @@ class DoxygenInstallerConan(ConanFile):
         tools.get(archive_url, sha256=self.source_sha)
         os.rename("doxygen-{!s}".format(archive_name), self._source_subfolder)
 
-        doxyfile = "FindDoxygen.cmake"
         cmakefile = "{!s}/CMakeLists.txt".format(self._source_subfolder)
         executeable = "doxygen"
         if self.settings.os_build == "Windows":
             executeable += ".exe"
-
-        tools.replace_in_file(doxyfile, "## MARKER POINT: DOXYGEN_EXECUTABLE", 'set(DOXYGEN_EXECUTABLE "${CONAN_DOXYGEN_ROOT}/%s" CACHE INTERNAL "")' % executeable)
-        tools.replace_in_file(doxyfile, "## MARKER POINT: DOXYGEN_VERSION", 'set(DOXYGEN_VERSION "%s" CACHE INTERNAL "")' % self.version)
 
         tools.replace_in_file(cmakefile, "include(version)", 'include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.cmake")')
         tools.replace_in_file(cmakefile, "project(doxygen)", """project(doxygen)
@@ -131,7 +126,6 @@ conan_basic_setup()""")
             tools.unzip(dest_file)
         os.unlink(dest_file)
 
-        doxyfile = "FindDoxygen.cmake"
         executeable = "doxygen"
         if self.settings.os_build == "Windows":
             executeable += ".exe"

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,13 +29,10 @@ class DoxygenInstallerConan(ConanFile):
         if self.settings.os_build in ["Linux", "Macos"] and self.settings.arch_build == "x86":
             raise ConanInvalidConfiguration("x86 is not supported on Linux or Macos")
 
-    def requirements(self):
-        if self.options.build_from_source:
-            self.requires("flex_installer/2.6.4@bincrafters/stable")
-            self.requires("bison_installer/3.3.2@bincrafters/stable")
-
     def build_requirements(self):
         if self.options.build_from_source:
+            self.build_requires("flex_installer/2.6.4@bincrafters/stable")
+            self.build_requires("bison_installer/3.3.2@bincrafters/stable")
             self.build_requires("cmake_installer/3.15.3@conan/stable")
 
     def source(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, tools
+from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 import shutil
@@ -7,6 +7,7 @@ import shutil
 class DoxygenInstallerConan(ConanFile):
     name = "doxygen_installer"
     version = "1.8.16"
+    source_sha = '336d367ca081dd6117ddaa7503314b4a0241e548b0571d6b413fb0b826468089'
     description = "A documentation system for C++, C, Java, IDL and PHP --- Note: Dot is disabled in this package"
     topics = ("conan", "doxygen", "installer", "devtool", "documentation")
     url = "https://github.com/bincrafters/conan-doxygen_installer"
@@ -16,13 +17,64 @@ class DoxygenInstallerConan(ConanFile):
     exports = ["LICENSE", "FindDoxygen.cmake"]
     exports_sources = ["FindDoxygen.cmake"]
 
-    settings = {"os_build": ["Windows", "Linux", "Macos"], "arch_build": ["x86", "x86_64"]}
-#   options = {"build_from_source": [False, True]} NOT SUPPORTED YET
-#   default_options = "build_from_source=False"
+    settings = "os_build", "arch_build", "compiler", "arch"
+    options = {"build_from_source": [False, True]}
+    default_options = "build_from_source=False"
+
+    generators = "cmake"
+
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
 
     def config(self):
         if self.settings.os_build in ["Linux", "Macos"] and self.settings.arch_build == "x86":
             raise ConanInvalidConfiguration("x86 is not supported on Linux or Macos")
+
+    def requirements(self):
+        if self.options.build_from_source:
+            self.requires("flex_installer/2.6.4@bincrafters/stable")
+            self.requires("bison_installer/3.3.2@bincrafters/stable")
+
+    def build_requirements(self):
+        if self.options.build_from_source:
+            self.build_requires("cmake_installer/3.15.3@conan/stable")
+
+    def source(self):
+        if not self.options.build_from_source:
+            return
+
+        archive_name = "Release_{!s}".format(self.version.replace('.', '_'))
+        archive_url = "https://github.com/doxygen/doxygen/archive/{!s}.zip".format(archive_name)
+        tools.get(archive_url, sha256=self.source_sha)
+        os.rename("doxygen-{!s}".format(archive_name), self._source_subfolder)
+
+        doxyfile = "FindDoxygen.cmake"
+        cmakefile = "{!s}/CMakeLists.txt".format(self._source_subfolder)
+        executeable = "doxygen"
+        if self.settings.os_build == "Windows":
+            executeable += ".exe"
+
+        tools.replace_in_file(doxyfile, "## MARKER POINT: DOXYGEN_EXECUTABLE", 'set(DOXYGEN_EXECUTABLE "${CONAN_DOXYGEN_ROOT}/%s" CACHE INTERNAL "")' % executeable)
+        tools.replace_in_file(doxyfile, "## MARKER POINT: DOXYGEN_VERSION", 'set(DOXYGEN_VERSION "%s" CACHE INTERNAL "")' % self.version)
+
+        tools.replace_in_file(cmakefile, "include(version)", 'include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.cmake")')
+        tools.replace_in_file(cmakefile, "project(doxygen)", """project(doxygen)
+include("../conanbuildinfo.cmake")
+conan_basic_setup()""")
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        # cmake.definitions["win_static"] = "ON" if self.settings.os == 'Windows' and self.options.shared == False else "OFF"
+        # cmake.definitions["use_libclang"] = "ON" if self.options.use_libclang else "OFF"
+
+        cmake.configure(source_folder=self._source_subfolder,
+                        build_folder=self._build_subfolder)
+        return cmake
+
+    def build_from_source(self):
+        self.settings.arch = self.settings.arch_build  # workaround for cross-building to get the correct arch during the build
+        cmake = self._configure_cmake()
+        cmake.build()
 
 
     def get_download_filename(self):
@@ -56,7 +108,7 @@ class DoxygenInstallerConan(ConanFile):
             self.run("diskutil eject %s" % (mount_point))
             tools.rmdir(mount_point)
 
-    def build(self):
+    def build_from_archive(self):
         # source location:
         # https://downloads.sourceforge.net/project/doxygen/rel-1.8.16/doxygen-1.8.16.linux.bin.tar.gz
 
@@ -84,7 +136,17 @@ class DoxygenInstallerConan(ConanFile):
         if self.settings.os_build == "Windows":
             executeable += ".exe"
 
+    def build(self):
+        if self.options.build_from_source:
+            self.build_from_source()
+        else:
+            self.build_from_archive()
+
     def package(self):
+        if self.options.build_from_source:
+            cmake = self._configure_cmake()
+            cmake.install()
+
         if self.settings.os_build == "Linux":
             srcdir = "doxygen-{}/bin".format(self.version)
             self.copy("*", dst="bin", src=srcdir)
@@ -98,3 +160,10 @@ class DoxygenInstallerConan(ConanFile):
 
     def package_info(self):
         self.env_info.PATH.append(os.path.join(self.package_folder,"bin"))
+
+    def package_id(self):
+        self.info.include_build_settings()
+        if self.settings.os_build == "Windows":
+            del self.info.settings.arch_build # same build is used for x86 and x86_64
+        del self.info.settings.arch
+        del self.info.settings.compiler


### PR DESCRIPTION
Of note:

- Put the build output in a separate build_subfolder.

- Inject the include of conanbuildinfo.cmake and the conan_basic_setup()
  directly into the CMakeLists.txt that comes from Doxygen. Doxygen is very
  particular about its source directory being the "top" directory.

- Requiring the flex_installer and bison_installer puts them in PATH during
  build. This is important because the find modules in CMake create macros
  FLEX_TARGET and BISON_TARGET, so we can't use the cmake_find_package
  generator. But, still want to use specific binaries, and not system binaries
  that may be too old.

Based on:

- Some code from Croydon's commit a5fe649a6d146f8f7ee90ae987e942c27ddf95b8

- some things from the tesseract recipe

- some ideas from the cmake_installer recipe

## Testing

I would claim that datalogics/dle#1327 is proving that DLE can build with a Doxygen built from this recipe; see the CI builds there.

Another way to test it would be to do something like this (on Mac with Xcode 10.2) to build it locally and try it out:

```
$ conan install . -if build -pr apple-clang-10.0-macos-10.9 -o doxygen_installer:build_from_source=True --build missing
$ conan source . -if build -sf build
$ conan build . -if build -sf build -bf build
$ conan package . -if build -sf build -bf build -pf pkg
```

You should see it _building_ Doxygen instead of unpacking an archive.

These are actually the [individual steps](https://docs.conan.io/en/latest/developing_packages/package_dev_flow.html#package-development-flow) of `conan create`, run locally.

After that, just see if it runs:

```
$ pkg/bin/doxygen
error: Doxyfile not found and no input file specified!
Doxygen version 1.8.16 (991c1254aa819cb3f67f0974d9abfd939b1da8e1*)
Copyright Dimitri van Heesch 1997-2019
...
```