### PR TITLE
Add the .gitattributes file with conanfile.py in it.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+conanfile.py   text eol=crlf


### PR DESCRIPTION
Add the .gitattributes file with conanfile.py in it to prevent having two recipes uploaded, one with CR-LF and one with LF.