### PR TITLE
Make minor modifications to allow building on Sparc 64

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Note that eol=lf means that CRLF will be converted to LF going into Git, and
+# will remain LF when checked out, even on Windows
+conanfile.py text eol=lf
+conandata.yml text eol=lf
+/util/*.py text eol=lf

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,13 +15,10 @@ class DoxygenInstallerConan(ConanFile):
     author = "Inexor <info@inexor.org>"
     license = "GPL-2.0-only"
     exports = ["LICENSE"]
-
     settings = "os_build", "arch_build", "compiler", "arch"
     options = {"build_from_source": [False, True]}
-    default_options = "build_from_source=False"
-
+    default_options = "build_from_source=True"
     generators = "cmake"
-
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
 
@@ -32,7 +29,7 @@ class DoxygenInstallerConan(ConanFile):
     def build_requirements(self):
         if self.options.build_from_source:
             self.build_requires("flex_installer/2.6.4@bincrafters/stable")
-            self.build_requires("bison_installer/3.3.2@bincrafters/stable")
+            self.build_requires('bison/3.5.3')
             self.build_requires("cmake_installer/3.15.3@conan/stable")
 
     def source(self):
@@ -138,7 +135,7 @@ conan_basic_setup()""")
             cmake = self._configure_cmake()
             cmake.install()
 
-        if self.settings.os_build == "Linux":
+        if self.settings.os_build not in ['Windows', 'Macos']:
             srcdir = "doxygen-{}/bin".format(self.version)
             self.copy("*", dst="bin", src=srcdir)
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -4,6 +4,8 @@
 from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
+    options = {"build_from_source": [False, True]}
+    default_options = "build_from_source=True"
     generators = "cmake_paths"
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Update bison build requirement to get one that will build on Sparc Solaris.
Add a .gitattributes file so the recipe is the same on Windows.
Add the build_from_source option to the test package so it can be set on the "conan create" command line.
