### PR TITLE
Tweaks to get AIX to build Doxygen

### DIFF
--- a/aix64_build
+++ b/aix64_build
@@ -1,0 +1,6 @@
+include(gcc-8-aix71-64)
+[env]
+LDFLAGS=-liconv
+CFLAGS=-maix64 -pthread -maltivec -mvsx -mcmodel=large
+CXXFLAGS=-maix64 -pthread -maltivec -mvsx -mcmodel=large
+


### PR DESCRIPTION
CMake checks for libiconv, but the check in Cmake was failing becuse it was using the wrong library, to fix that a profile for building on AIX was added, it sets the environment variable LDFLAGS so that it is added when linking when used.
The Doxygen project's CMakeLists.txt needed to be patched so  it would not fail when it couldn't find libiconv.
Doxygen code had many issues building on AIX with gcc, needed to add a header  file, undefine TRUE and FALSE, and also to set the flag -mcmodel=large or the assembler throws errors.